### PR TITLE
Avoid possible SEGFAULT on DESTROY stage

### DIFF
--- a/R3.xs
+++ b/R3.xs
@@ -2895,6 +2895,7 @@ match(SV* r3_sv, SV *str_sv)
 void DESTROY(SV* r3_sv)
     PPCODE:
         void* pad = SvRV(SvRV(r3_sv));
+        if (!pad) return;
         int branch_n = *(int*)((char*)pad + sizeof(node*));
         SV** target = (SV**)((char*)pad + sizeof(node*) + sizeof(int));
         for(int i=0; i<branch_n; ++i)

--- a/t/destroy.t
+++ b/t/destroy.t
@@ -1,0 +1,36 @@
+# Before 'make install' is performed this script should be runnable with
+# 'make test'. After 'make install' it should work as 'perl Router-R3.t'
+
+#########################
+
+# change 'tests => 1' to 'tests => last_test_to_print';
+
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+BEGIN { use_ok('Router::R3') };
+
+my %router;
+
+sub _init {
+    %router = (
+        POST => Router::R3->new(
+            '/api/v1/event/create' => sub {},
+            '/api/v1/account/i/{i_account:\d+}/status' =>  sub {},
+        ),
+        GET => Router::R3->new(
+             '/api/v1/account/i/{i_account:\d+}/status' => sub {},
+             '/api/v1/account/{id}/status'              => sub {},
+        ),
+        DELETE => Router::R3->new(
+             '/api/v1/group/i/{i_group:\d+}' => sub {},
+             '/api/v1/group/{name}'          => sub {},
+        ),
+    );
+}
+
+_init();
+
+ok( $router{POST}->match( '/api/v1/event/create' ) );
+# ensure that there are no Segmentation Fault on exit


### PR DESCRIPTION
I have observed issue - when my API service restarts, it sometimes caused Segmentation Fault error on exit. Created an test example, and small fix for the issue.